### PR TITLE
update counterbalancing again 

### DIFF
--- a/pyensemble/views.py
+++ b/pyensemble/views.py
@@ -330,6 +330,13 @@ def run_experiment(request, experiment_id=None):
         if ticket.expired:
             return HttpResponseBadRequest('The ticket has expired')
 
+        # Get the SONA code if there is one
+        sona_code = request.GET.get('sona',None)
+
+        # Deal with the situation in which we are trying to access using a survey code from SONA, but no code has been set
+        if 'sona' in request.GET.keys() and not sona_code:
+            return render(request,'pyensemble/error.html',{'msg':'No SONA survey code was specified!','next':'/'})
+
         # Initialize a session in the PyEnsemble session table
         session = Session.objects.create(experiment=ticket.experiment, ticket=ticket)
 
@@ -347,7 +354,7 @@ def run_experiment(request, experiment_id=None):
             'last_in_loop': {},
             'visit_count': {},
             'running': True,
-            'sona': request.GET.get('sona',None)
+            'sona': sona_code,
             })
 
     # Set the experiment session info


### PR DESCRIPTION
this branch was created from musmem_merge_fix after the last time merge_fix was merged with master. bio_working was updated to exclude more subjects (one's that weren't able to complete during Spring 2020). Also, tweaked the counterbalancing so that when the participant count is odd, it assigns stims to trials start with trial 20 and going backwards. Before this tweak, trial 20 wasn't being randomized participant to participant as well because all by the time we get through first 19 trials of a subject, the pool of possible loops is reduced (and the loop assigned the least amount of times across subjects to trial 20 wasn't available because it was already assigned). 