### PR TITLE
fixed issue of ticket-generation inputs being locked out

### DIFF
--- a/pyensemble/static/pyensemble/js/editor.js
+++ b/pyensemble/static/pyensemble/js/editor.js
@@ -196,22 +196,22 @@ function setEditStatus(status){
     }
 
     if (!status){
-        $("#content-right input,textarea").attr({'readonly':false});
-        $("#content-right input:checkbox, select").attr({'disabled':false});
-        $("#content-right .dateinput").attr({'disabled':false});
+        $(".editor input,textarea").attr({'readonly':false});
+        $(".editor input:checkbox, select").attr({'disabled':false});
+        $(".editor .dateinput").attr({'disabled':false});
         $(".editor.form-actions").removeClass('d-none');
         $("#formTableEditButton").addClass('btn btn-danger active');
     } else {
-        $("#content-right input,textarea").attr({'readonly':true});
-        $("#content-right input:checkbox, select").attr({'disabled':true});
-        $("#content-right .dateinput").attr({'disabled':true});
+        $(".editor input,textarea").attr({'readonly':true});
+        $(".editor input:checkbox, select").attr({'disabled':true});
+        $(".editor .dateinput").attr({'disabled':true});
         $(".editor.form-actions").addClass('d-none');
         $("#formTableEditButton").removeClass('btn-danger active');
     }
 }
 
 function toggleEditStatus(){
-    var new_status = $("#content-right input,textarea").attr('readonly') == 'readonly' ? false : true;
+    var new_status = $(".editor input,textarea").attr('readonly') == 'readonly' ? false : true;
 
     setEditStatus(new_status);
 }


### PR DESCRIPTION
Narrowed the input lockout in non-edit mode to the .editor class instead of all of content-right.