### PR TITLE
changed logging directory after setting up /var/log/pyensemble such t…

### DIFF
--- a/pyensemble/settings/settings.py
+++ b/pyensemble/settings/settings.py
@@ -195,13 +195,13 @@ LOGGING = {
         'file': {
             'level': 'DEBUG',
             'class': 'logging.FileHandler',
-            'filename': '/home/pyensemble/log/django-debug.txt',
+            'filename': '/var/log/pyensemble/django-debug.txt',
             'formatter': 'timestamped',
         },
         'error-file': {
             'level': 'ERROR',
             'class': 'logging.FileHandler',
-            'filename': '/home/pyensemble/log/django-error.txt',
+            'filename': '/var/log/pyensemble/django-error.txt',
             'formatter': 'timestamped',
         }
     },


### PR DESCRIPTION
…hat it is owned by apache and has sticky group www. Adding server users to the www group allows them to view the Django error logs that are written to in production.